### PR TITLE
eviscerate runLighthouse

### DIFF
--- a/clients/devtools-entry.js
+++ b/clients/devtools-entry.js
@@ -35,21 +35,6 @@ function setUpWorkerConnection(port) {
   return new RawProtocol(port);
 }
 
-/**
- * @param {string} url
- * @param {LH.Flags} flags Lighthouse flags.
- * @param {Array<string>} categoryIDs Name values of categories to include.
- * @param {RawProtocol} connection
- * @return {Promise<LH.RunnerResult|void>}
- */
-function runLighthouse(url, flags, categoryIDs, connection) {
-  // Default to 'info' logging level.
-  flags.logLevel = flags.logLevel || 'info';
-  flags.channel = 'devtools';
-  const config = getDefaultConfigForCategories(categoryIDs);
-  return lighthouse(url, flags, config, connection);
-}
-
 /** @param {(status: [string, string, string]) => void} listenCallback */
 function listenForStatus(listenCallback) {
   log.events.addListener('status', listenCallback);
@@ -59,7 +44,8 @@ if (typeof module !== 'undefined' && module.exports) {
   // export for require()ing (via browserify).
   module.exports = {
     setUpWorkerConnection,
-    runLighthouse,
+    lighthouse,
+    getDefaultConfigForCategories,
     listenForStatus,
     registerLocaleData,
     lookupLocale,
@@ -72,7 +58,9 @@ if (typeof self !== 'undefined') {
   // @ts-ignore
   self.setUpWorkerConnection = setUpWorkerConnection;
   // @ts-ignore
-  self.runLighthouse = runLighthouse;
+  self.runLighthouse = lighthouse;
+  // @ts-ignore
+  self.getDefaultConfigForCategories = getDefaultConfigForCategories;
   // @ts-ignore
   self.listenForStatus = listenForStatus;
   // @ts-ignore


### PR DESCRIPTION
@brendankenny this yeah?

it's accompanied with these devtools changes:

```diff
diff --git a/front_end/audits_worker/AuditsService.js b/front_end/audits_worker/AuditsService.js
index a66191cb..f8d6bc80 100644
--- a/front_end/audits_worker/AuditsService.js
+++ b/front_end/audits_worker/AuditsService.js
@@ -51,8 +51,19 @@ var AuditsService = class {  // eslint-disable-line
       this.statusUpdate(message[1]);
     });
 
+
     return Promise.resolve()
-        .then(_ => self.runLighthouseInWorker(this, params.url, params.flags, params.categoryIDs))
+        .then(_ => {
+          const flags = params.flags;
+          flags.logLevel=flags.logLevel||'info';
+          flags.channel='devtools';
+
+          const connection = self.setUpWorkerConnection(this);
+          const config = getDefaultConfigForCategories(params.categoryIDs);
+          const url = params.url;
+
+          return self.runLighthouse(url, flags, config, connection)
+        })
         .then(/** @type {!ReportRenderer.RunnerResult} */ result => {
           // Keep all artifacts on the result, no trimming
           return result;
@@ -126,6 +137,8 @@ var AuditsService = class {  // eslint-disable-line
 
 // Make lighthouse and traceviewer happy.
 global = self;
+global.devtools=true;
+
 global.isVinn = true;
 global.document = {};
 global.document.documentElement = {};

```